### PR TITLE
Update magit-p4 for compatility with magit-2.1 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Attention! This is in development. Some of the info below is nothing but a plain
 
 ## Requirements ##
 
-Emacs 24.x with `magit` and `p4` packages installed. You do not have to install these packages if you use Melpa service - all required dependencies will be downloaded altogether with `magit-p4`.
+Emacs 24.x with `magit-2.1` or newer and `p4` packages installed. You do not have to install these packages if you use Melpa service - all required dependencies will be downloaded altogether with `magit-p4`.
 `git-p4` add-on is obviously required.
 
 ## Installation ##

--- a/magit-p4.el
+++ b/magit-p4.el
@@ -48,9 +48,9 @@
 
 ;;;###autoload
 (defun magit-p4-clone (depot-path &optional target-dir)
-  "Clone given depoth path.
+  "Clone given DEPOT-PATH.
 
-   The first argument is P4 depot path to clone. The second optional argument
+   The first argument is P4 depot path to clone. The TARGET-DIR argument
    is directory which will hold the Git repository."
   (interactive
    (append (list (p4-read-arg-string "Depot path: " "//" 'filespec))
@@ -63,7 +63,7 @@
 
 ;;;###autoload
 (defun magit-p4-sync (&optional depot-path)
-  "Synchronize with default and/or given depoth path.
+  "Synchronize with default and/or given DEPOT-PATH.
 
    The optional argument is P4 depot path which will be synchronised with.
    If not present, git-p4 will try to synchronize with default depot path which
@@ -78,13 +78,13 @@
 
 ;;;###autoload
 (defun magit-p4-rebase ()
-  "Runs git-p4 rebase."
+  "Run git-p4 rebase."
   (interactive)
   (magit-run-git-async "p4" "rebase"))
 
 (defun magit-p4/server-edit-end-keys ()
   "Private function.
-   Binds C-c C-c keys to finish editing submit log
+Binds C-c C-c keys to finish editing submit log
    when using emacsclient tools."
   (when (current-local-map)
     (use-local-map (copy-keymap (current-local-map))))
@@ -93,7 +93,7 @@
 
 ;;;###autoload
 (defun magit-p4-submit ()
-  "Runs git-p4 submit."
+  "Run git-p4 submit."
   (interactive)
   (with-editor "P4EDITOR"
     (magit-run-git-with-editor "p4" "submit" (magit-p4-submit-arguments))))
@@ -174,7 +174,8 @@
 (add-hook 'server-switch-hook 'magit-p4/server-edit-end-keys)
 
 (defun magit-p4/insert-job (&optional job)
-  "Inserts job reference in a buffer.
+  "Insert JOB reference in a buffer.
+
   The insertion assumes that it should be 'Jobs:' entry in the buffer.
   If not - it inserts such at the current point of the buffer. Then it asks (if
   applied interactively) for a job id using `p4` completion function.

--- a/magit-p4.el
+++ b/magit-p4.el
@@ -92,12 +92,8 @@
 (defun magit-p4-submit ()
   "Runs git-p4 submit."
   (interactive)
-  ;; git-p4 invokes editor using values of P4EDITOR or GIT_EDITOR variables
-  ;; here we temporarily set P4EDITOR (it has precedence in git-p4) to "emacsclient"
-  (let ((p4editor (getenv "P4EDITOR")))
-    (setenv "P4EDITOR" "emacsclient")
-    (magit-run-git-async "p4" "submit" magit-custom-options)
-    (setenv "P4EDITOR" p4editor)))
+  (with-editor "P4EDITOR"
+    (magit-run-git-with-editor "p4" "submit" (magit-p4-submit-arguments))))
 
 ;;; Utilities
 

--- a/magit-p4.el
+++ b/magit-p4.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2014 Damian T. Dobroczyński
 ;;
 ;; Author: Damian T. Dobroczy\\'nski <qoocku@gmail.com>
+;; Version: 1.1
+;; Package-Requires: ((magit "2.1") (magit-popup) (p4) (cl-lib))
 ;; Keywords: vc tools
+;; URL: https://github.com/qoocku/magit-p4
 ;; Package: magit-p4
 
 ;; Magit-p4 is free software; you can redistribute it and/or modify it

--- a/magit-p4.el
+++ b/magit-p4.el
@@ -51,11 +51,12 @@
    is directory which will hold the Git repository."
   (interactive
    (append (list (p4-read-arg-string "Depot path: " "//" 'filespec))
-           (if (and (not (search "destination=" magit-custom-options))
+           (if (and (not (search "destination=" (magit-p4-clone-arguments)))
                     current-prefix-arg)
              (read-directory-name "Target directory: ")
              nil)))
-  (magit-run-git-async "p4" "clone" (cons depot-path magit-custom-options)))
+  (magit-run-git-async "p4" "clone" (cons depot-path (magit-p4-clone-arguments))))
+
 
 ;;;###autoload
 (defun magit-p4-sync (&optional depot-path)
@@ -69,14 +70,14 @@
      (list (p4-read-arg-string "With (another) depot path: " "//" 'filespec))))
   (magit-run-git-async "p4" "sync"
                        (cond (depot-path
-                              (cons depot-path magit-custom-options))
-                             (t magit-custom-options))))
+                              (cons depot-path (magit-p4-sync-arguments)))
+                             (t (magit-p4-sync-arguments)))))
 
 ;;;###autoload
 (defun magit-p4-rebase ()
   "Runs git-p4 rebase."
   (interactive)
-  (magit-run-git-async "p4" "rebase" magit-custom-options))
+  (magit-run-git-async "p4" "rebase"))
 
 (defun magit-p4/server-edit-end-keys ()
   "Private function.

--- a/magit-p4.el
+++ b/magit-p4.el
@@ -98,11 +98,6 @@ Binds C-c C-c keys to finish editing submit log
   (with-editor "P4EDITOR"
     (magit-run-git-with-editor "p4" "submit" (magit-p4-submit-arguments))))
 
-;;; Utilities
-
-(defun magit-p4-enabled ()
-  t)
-
 ;;; Keymaps
 
 (easy-menu-define magit-p4-extension-menu
@@ -110,10 +105,10 @@ Binds C-c C-c keys to finish editing submit log
   "Git P4 extension menu"
   '("Git P4"
     :visible magit-p4-mode
-    ["Clone" magit-p4-clone (magit-p4-enabled)]
-    ["Sync" magit-p4-sync (magit-p4-enabled)]
-    ["Rebase" magit-p4-rebase (magit-p4-enabled)]
-    ["Submit" magit-p4-submit (magit-p4-enabled)]))
+    ["Clone" magit-p4-clone t]
+    ["Sync" magit-p4-sync t]
+    ["Rebase" magit-p4-rebase t]
+    ["Submit" magit-p4-submit t]))
 
 (easy-menu-add-item 'magit-mode-menu
                     '("Extensions")


### PR DESCRIPTION
This patchset updates magit-p4 to follow changes in magit.
This PR contains two essential changes:
1. Change way of defining popups
2. Change variable used for passing arguments to git commands.
