### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+
+before_install:
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use
+
+env:
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+
+install:
+  - emacs --version
+  - emacs --batch --script tests/build-test.el
+
+script:
+  - echo "Nothing to test yet"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Git-p4 plugin for Magit #
 
 [![MELPA](http://melpa.org/packages/magit-p4-badge.svg)](http://melpa.org/#/magit-p4)
+[![Build Status](https://travis-ci.org/lexa/magit-p4.svg?branch=master)](https://travis-ci.org/lexa/magit-p4)
 
 Attention! This is in development. Some of the info below is nothing but a plain lie!
 

--- a/tests/build-test.el
+++ b/tests/build-test.el
@@ -1,0 +1,6 @@
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/") t)
+(package-initialize)
+(package-refresh-contents)
+;(setq byte-compile-error-on-warn t)
+(package-install-file "magit-p4.el")


### PR DESCRIPTION
Check that package builds successfully.

I failed to configure travis-ci to build qoocku/magit-p4, so build badge will should status of lexa/magit-p4. 

@qoocku 
If you have time, could you please configure travis-ci so it will check your version of the repo?
